### PR TITLE
Pdf format aangepast

### DIFF
--- a/laravel/app/Http/Controllers/ReportController.php
+++ b/laravel/app/Http/Controllers/ReportController.php
@@ -400,6 +400,7 @@ class ReportController extends Controller
                     'code' => $check->code,
                     'notes' => $item->notes,
                     'photos' => $item->photos ?? [],
+                    'status' => $item->status,
                 ];
             }
         }

--- a/laravel/resources/views/reports/pdf.blade.php
+++ b/laravel/resources/views/reports/pdf.blade.php
@@ -65,19 +65,30 @@
         <p><strong>Verzonden op:</strong> {{ optional($report->submitted_at)->format('d-m-Y H:i') ?? now()->format('d-m-Y H:i') }}</p>
     </div>
 
-    @if (!empty($groupedChecks['gecontroleerd']))
+    @php
+        $completedChecks = collect($groupedChecks['gecontroleerd'] ?? []);
+        if (!empty($groupedChecks['bijzonderheden'])) {
+            $completedChecks = $completedChecks->merge($groupedChecks['bijzonderheden']);
+        }
+    @endphp
+
+    @if ($completedChecks->isNotEmpty())
         <h2>Gecontroleerd</h2>
         <table>
             <thead>
                 <tr>
+                    <th style="width: 10%;">Status</th>
                     <th style="width: 25%;">Categorie</th>
-                    <th style="width: 55%;">Controle</th>
+                    <th style="width: 45%;">Controle</th>
                     <th style="width: 20%;">Code</th>
                 </tr>
             </thead>
             <tbody>
-                @foreach ($groupedChecks['gecontroleerd'] as $check)
+                @foreach ($completedChecks as $check)
                     <tr>
+                        <td style="text-align: center;">
+                            {{ ($check['status'] ?? 'gecontroleerd') === 'bijzonderheden' ? 'X' : 'V' }}
+                        </td>
                         <td>{{ $check['category'] }}</td>
                         <td>{{ $check['label'] }}</td>
                         <td class="muted">{{ $check['code'] ?? '-' }}</td>


### PR DESCRIPTION
# Omschrijving
Het pdf bestand is nu netjes geformat met elke opdracht die een X of een V status heeft. Opdrachten met een X status staan met toelichting onder de bijzonderheden lijst.


# Test scenario
Testplan PDF convertie:
1: Rapport invullen, ondertekenen en indienen verwacht: PDF verschijnt onder “Downloads” en opent correct.

2: Tweede indiening van hetzelfde rapport verwacht: nieuwe PDF‑bestandsnaam, oude PDF verdwijnt, database wijst naar nieuwe path.

3: Open het pdf rapport via de knop in het rapportage menu

4: PDF is een eenvoudige HTML-template: titel met schipnaam/id, meta-regel (schipnummer, monteur, status, verzenddatum), tabel “Gecontroleerd” (V/X, categorie, controle, code), aparte tabel “Bijzonderheden” met opmerkingen/fotobestandsnamen, en een handtekening-afbeelding.

# Checklist:

- [x] Code volgt de Code Conventions
- [x] Ik heb mijn eigen code gereviewd
- [x] Ik heb commentaar toegevoegd aan mijn code
- [x] Ik heb de documentatie (user-story, ontwerp, testen, verbetervoorstel) bijgewerkt
- [x] Ik heb een functionele test uitgevoerd volgens het test scenario

