### PR TITLE
opslaan knop fix

### DIFF
--- a/laravel/app/Http/Controllers/ReportController.php
+++ b/laravel/app/Http/Controllers/ReportController.php
@@ -259,7 +259,8 @@ class ReportController extends Controller
             'checks.*.photos.*' => ['nullable', 'image', 'max:5120'],
         ]);
 
-        [$ok, $message] = $this->syncCheckItems($report, $validated['checks']);
+        // Opslaan van voortgang mag ook met openstaande (pending) checks.
+        [$ok, $message] = $this->syncCheckItems($report, $validated['checks'], requireCompletion: false);
 
         if (!$ok) {
             return back()
@@ -348,20 +349,22 @@ class ReportController extends Controller
 
     /**
      * Synchroniseert check items met de database.
-     * - Controleert of alle checks compleet zijn (niet 'pending')
+     * - Kan optioneel afdwingen dat alle checks afgerond zijn (geen 'pending')
      * - Slaat status, notities en foto's op per check
      * - Verwijdert oude foto's als een check terug naar 'gecontroleerd' gaat
      * 
      * @return array [bool $success, string|null $errorMessage]
      */
-    private function syncCheckItems(Report $report, array $checksPayload): array
+    private function syncCheckItems(Report $report, array $checksPayload, bool $requireCompletion = true): array
     {
-        $complete = collect($checksPayload)->every(
-            fn($check) => in_array($check['status'], ['gecontroleerd', 'bijzonderheden'], true)
-        );
+        if ($requireCompletion) {
+            $complete = collect($checksPayload)->every(
+                fn($check) => in_array($check['status'], ['gecontroleerd', 'bijzonderheden'], true)
+            );
 
-        if (!$complete) {
-            return [false, 'Niet alle controles zijn toegewezen aan Gecontroleerd of Bijzonderheden.'];
+            if (!$complete) {
+                return [false, 'Niet alle controles zijn toegewezen aan Gecontroleerd of Bijzonderheden.'];
+            }
         }
 
         foreach ($checksPayload as $checkId => $payload) {

--- a/laravel/resources/views/tabblad.blade.php
+++ b/laravel/resources/views/tabblad.blade.php
@@ -448,7 +448,8 @@ function initChecklistBoard() {
     }
 
     function updateActionButtons() {
-        const disabledSave = pendingHasItems;
+        // Opslaan moet altijd kunnen; verzenden alleen zonder openstaande items en met handtekening.
+        const disabledSave = false;
         const disabledSend = pendingHasItems || !signatureDirty;
 
         if (saveBtn) saveBtn.disabled = disabledSave;


### PR DESCRIPTION
# Omschrijving
rapportage kunnen nu opgeslagen worden ook als ze niet helemaal zijn ingevuld


# Test scenario
Open een rapportage zet een opdracht in open en check of het opslaan werkt
# Checklist:

- [x] Code volgt de Code Conventions
- [x] Ik heb mijn eigen code gereviewd
- [x] Ik heb commentaar toegevoegd aan mijn code
- [x] Ik heb de documentatie (user-story, ontwerp, testen, verbetervoorstel) bijgewerkt
- [x] Ik heb een functionele test uitgevoerd volgens het test scenario

